### PR TITLE
Remove optional annotation

### DIFF
--- a/schema/generate_jsonld.py
+++ b/schema/generate_jsonld.py
@@ -1,0 +1,6 @@
+import json
+from src.dataset import ScientificDataset, EditableScientificDataset
+
+js_schema = EditableScientificDataset.model_json_schema()
+with open("schema/dataset_schema.json", "w") as f:
+    f.write(json.dumps(js_schema, indent=2))

--- a/schema/src/base.py
+++ b/schema/src/base.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime
 from enum import Enum
-from typing import Any, List, Optional, Union, Literal
+from typing import Any, List, Union, Literal
 
 
 from pydantic import (
@@ -92,10 +92,10 @@ class CreativeWork(SchemaBaseModel):
         "software source code, digital documents, etc.",
     )
     name: str = Field(description="Submission's name or title", title="Name or title")
-    description: Optional[str] = Field(
+    description: str = Field(
         description="The description of the creative work.", default=None
     )
-    url: Optional[HttpUrl] = Field(
+    url: HttpUrl = Field(
         title="URL",
         description="A URL to the creative work.",
         default=None,
@@ -109,10 +109,10 @@ class Person(SchemaBaseModel):
     name: str = Field(
         description="A string containing the full name of the person. Personal name format: Family Name, Given Name."
     )
-    email: Optional[EmailStr] = Field(
+    email: EmailStr = Field(
         description="A string containing an email address for the person.", default=None
     )
-    identifier: Optional[List[str]] = Field(
+    identifier: List[str] = Field(
         description="Unique identifiers for the person. Where identifiers can be encoded as URLs, enter URLs here.",
         default=None,
     )
@@ -127,12 +127,12 @@ class Organization(SchemaBaseModel):
         default="Organization",
     )
     name: str = Field(description="Name of the provider organization or repository.")
-    url: Optional[HttpUrl] = Field(
+    url: HttpUrl = Field(
         title="URL",
         description="A URL to the homepage for the organization.",
         default=None,
     )
-    address: Optional[str] = Field(
+    address: str = Field(
         description="Full address for the organization - e.g., “8200 Old Main Hill, Logan, UT 84322-8200”.",
         default=None,
     )  # Should address be a string or another constrained type?
@@ -148,7 +148,7 @@ class Affiliation(Organization):
 
 
 class Provider(Person):
-    identifier: Optional[str] = Field(
+    identifier: str = Field(
         description="ORCID identifier for the person.",
         json_schema_extra={
             "pattern": orcid_pattern,
@@ -157,18 +157,18 @@ class Provider(Person):
         },
         default=None,
     )
-    email: Optional[EmailStr] = Field(
+    email: EmailStr = Field(
         description="A string containing an email address for the provider.",
         default=None,
     )
-    affiliation: Optional[Affiliation] = Field(
+    affiliation: Affiliation = Field(
         description="The affiliation of the creator with the organization.",
         default=None,
     )
 
 
 class Creator(Person):
-    identifier: Optional[str] = Field(
+    identifier: str = Field(
         description="ORCID identifier for creator.",
         json_schema_extra={
             "pattern": orcid_pattern,
@@ -177,18 +177,18 @@ class Creator(Person):
         },
         default=None,
     )
-    email: Optional[EmailStr] = Field(
+    email: EmailStr = Field(
         description="A string containing an email address for the creator.",
         default=None,
     )
-    affiliation: Optional[Affiliation] = Field(
+    affiliation: Affiliation = Field(
         description="The affiliation of the creator with the organization.",
         default=None,
     )
 
 
 class Contributor(Person):
-    identifier: Optional[str] = Field(
+    identifier: str = Field(
         description="ORCID identifier for contributor.",
         json_schema_extra={
             "pattern": orcid_pattern,
@@ -197,11 +197,11 @@ class Contributor(Person):
         },
         default=None,
     )
-    email: Optional[EmailStr] = Field(
+    email: EmailStr = Field(
         description="A string containing an email address for the creator.",
         default=None,
     )
-    affiliation: Optional[Affiliation] = Field(
+    affiliation: Affiliation = Field(
         description="The affiliation of the creator with the organization.",
         default=None,
     )
@@ -222,7 +222,7 @@ class FunderOrganization(Organization):
 
 class PublisherOrganization(Organization):
     name: str = Field(description="Name of the publishing organization.")
-    url: Optional[HttpUrl] = Field(
+    url: HttpUrl = Field(
         title="URL",
         description="A URL to the homepage for the publisher organization or repository.",
         default=None,
@@ -276,20 +276,20 @@ class Published(DefinedTerm):
 
 
 class HasPart(CreativeWork):
-    url: Optional[HttpUrl] = Field(
+    url: HttpUrl = Field(
         title="URL", description="The URL address to the data resource.", default=None
     )
-    description: Optional[str] = Field(
+    description: str = Field(
         description="Information about a related resource that is part of this resource.",
         default=None,
     )
 
 
 class IsPartOf(CreativeWork):
-    url: Optional[HttpUrl] = Field(
+    url: HttpUrl = Field(
         title="URL", description="The URL address to the data resource.", default=None
     )
-    description: Optional[str] = Field(
+    description: str = Field(
         description="Information about a related resource that this resource is a "
         "part of - e.g., a related collection.",
         default=None,
@@ -297,25 +297,25 @@ class IsPartOf(CreativeWork):
 
 
 class MediaObjectPartOf(CreativeWork):
-    url: Optional[HttpUrl] = Field(
+    url: HttpUrl = Field(
         title="URL",
         description="The URL address to the related metadata document.",
         default=None,
     )
-    description: Optional[str] = Field(
+    description: str = Field(
         description="Information about a related metadata document.", default=None
     )
 
 
 class SubjectOf(CreativeWork):
-    url: Optional[HttpUrl] = Field(
+    url: HttpUrl = Field(
         title="URL",
         description="The URL address that serves as a reference to access additional details related to the record. "
         "It is important to note that this type of metadata solely pertains to the record itself and "
         "may not necessarily be an integral component of the record, unlike the HasPart metadata.",
         default=None,
     )
-    description: Optional[str] = Field(
+    description: str = Field(
         description="Information about a related resource that is about or describes this "
         "resource - e.g., a related metadata document describing the resource.",
         default=None,
@@ -397,12 +397,12 @@ class SpatialReference(SchemaBaseModel):
         title="SRS Type",
         description="Type of the spatial reference system, either Geographic or Projected.",
     )
-    code: Optional[str] = Field(
+    code: str = Field(
         title="Code",
         description="Code of the spatial reference system.",
         default=None,
     )
-    wktString: Optional[str] = Field(
+    wktString: str = Field(
         title="SRS WKT String",
         description="The string representation of the spatial reference system in Well-Known-Text format.",
         default=None,
@@ -429,16 +429,16 @@ class Grant(SchemaBaseModel):
         title="Name or title",
         description="A text string indicating the name or title of the grant or financial assistance.",
     )
-    description: Optional[str] = Field(
+    description: str = Field(
         description="A text string describing the grant or financial assistance.",
         default=None,
     )
-    identifier: Optional[str] = Field(
+    identifier: str = Field(
         title="Funding identifier",
         description="Grant award number or other identifier.",
         default=None,
     )
-    funder: Optional[FunderOrganization] = Field(
+    funder: FunderOrganization = Field(
         description="The organization that provided the funding or sponsorship.",
         default=None,
     )
@@ -456,7 +456,7 @@ class TemporalCoverage(SchemaBaseModel):
             },
         },
     )
-    endDate: Optional[datetime] = Field(
+    endDate: datetime = Field(
         title="End date",
         description="A date/time object containing the instant corresponding to the termination of the time "
         "interval (ISO8601 formatted date - YYYY-MM-DDTHH:MM). If the ending date is left off, "
@@ -564,28 +564,28 @@ class PropertyValue(SchemaBaseModel):
         )
     )
 
-    propertyID: Optional[str] = Field(
+    propertyID: str = Field(
         title="Property ID", description="The ID of the property.", default=None
     )
-    unitCode: Optional[str] = Field(
+    unitCode: str = Field(
         title="Measurement unit",
         description="The unit of measurement for the value.",
         default=None,
     )
-    description: Optional[str] = Field(
+    description: str = Field(
         description="A description of the property.", default=None
     )
-    minValue: Optional[float] = Field(
+    minValue: float = Field(
         title="Minimum value",
         description="The minimum allowed value for the property.",
         default=None,
     )
-    maxValue: Optional[float] = Field(
+    maxValue: float = Field(
         title="Maximum value",
         description="The maximum allowed value for the property.",
         default=None,
     )
-    measurementTechnique: Optional[str] = Field(
+    measurementTechnique: str = Field(
         title="Measurement technique",
         description="A technique or technology used in a measurement.",
         default=None,
@@ -602,20 +602,20 @@ class Place(SchemaBaseModel):
         default="Place",
         description="Represents the focus area of the record's content.",
     )
-    name: Optional[str] = Field(description="Name of the place.", default=None)
-    geo: Optional[Union[GeoCoordinates, GeoShape]] = Field(
+    name: str = Field(description="Name of the place.", default=None)
+    geo: Union[GeoCoordinates, GeoShape] = Field(
         description="Specifies the geographic coordinates of the place in the form of a point location, line, "
         "or area coverage extent.",
         default=None,
     )
 
-    additionalProperty: Optional[List[PropertyValue]] = Field(
+    additionalProperty: List[PropertyValue] = Field(
         title="Additional properties",
         default=None,
         description="Additional properties of the place.",
     )
 
-    srs: Optional[SpatialReference] = Field(
+    srs: SpatialReference = Field(
         description="The spatial reference system associated with the Place's geographic representation",
         default=None,
     )
@@ -639,7 +639,7 @@ class MediaObject(SchemaBaseModel):
         title="Content URL",
         description="The direct URL link to access or download the actual content of the media object.",
     )
-    encodingFormat: Optional[str] = Field(
+    encodingFormat: str = Field(
         title="Encoding format",
         description="Represents the specific file format in which the media is encoded.",
         default=None,
@@ -650,12 +650,12 @@ class MediaObject(SchemaBaseModel):
         "unit of measurement.",
     )
     name: str = Field(description="The name of the media object (file).")
-    sha256: Optional[str] = Field(
+    sha256: str = Field(
         title="SHA-256",
         description="The SHA-256 hash of the media object.",
         default=None,
     )
-    isPartOf: Optional[List[MediaObjectPartOf]] = Field(
+    isPartOf: List[MediaObjectPartOf] = Field(
         title="Is part of",
         description="Link to or citation for a related metadata document that this media object is a part of",
         default=None,
@@ -703,12 +703,12 @@ class DataDownload(MediaObject):
         default="DataDownload",
         description="All or part of a Dataset in downloadable form.",
     )
-    measurementMethod: Optional[Union[DefinedTerm, HttpUrl, str]] = Field(
+    measurementMethod: Union[DefinedTerm, HttpUrl, str] = Field(
         title="Measurement method",
         description="A subproperty of measurementTechnique that can be used for specifying specific methods, in particular via MeasurementMethodEnum.",
         default=None,
     )
-    measurementTechnique: Optional[Union[DefinedTerm, HttpUrl, str]] = Field(
+    measurementTechnique: Union[DefinedTerm, HttpUrl, str] = Field(
         title="Measurement technique",
         description="A technique, method or technology used in an Observation, StatisticalVariable or Dataset (or DataDownload, DataCatalog), corresponding to the method used for measuring the corresponding variable(s) (for datasets, described using variableMeasured; for Observation, a StatisticalVariable). Often but not necessarily each variableMeasured will have an explicit representation as (or mapping to) an property such as those defined in Schema.org, or other RDF vocabularies and 'knowledge graphs'. In that case the subproperty of variableMeasured called measuredProperty is applicable.",
         default=None,
@@ -731,43 +731,30 @@ MediaType = Union[MediaObject, DataDownload, VideoObject]
 
 
 class Dataset(CreativeWork):
-    measurementMethod: Optional[
-        Union[
-            HttpUrl,
-            List[HttpUrl],
-            DefinedTerm,
-            List[DefinedTerm],
-            str,
-            List[str],
-        ]
+    measurementMethod: Union[
+        HttpUrl,
+        List[HttpUrl],
+        DefinedTerm,
+        List[DefinedTerm],
+        str,
+        List[str],
     ] = None
-    issn: Optional[Union[str, List[str]]] = None
-    measurementTechnique: Optional[
-        Union[
-            str,
-            List[str],
-            HttpUrl,
-            List[HttpUrl],
-            DefinedTerm,
-            List[DefinedTerm],
-        ]
+    issn: Union[str, List[str]] = None
+    measurementTechnique: Union[
+        str,
+        List[str],
+        HttpUrl,
+        List[HttpUrl],
+        DefinedTerm,
+        List[DefinedTerm],
     ] = None
-    catalog: Optional[Union["DataCatalog", List["DataCatalog"]]] = None
-    variablesMeasured: Optional[
-        Union[str, List[str], "PropertyValue", List["PropertyValue"]]
-    ] = None
-    variableMeasured: Optional[
-        Union[
-            str,
-            List[str],
-            "PropertyValue",
-            List["PropertyValue"],
-        ]
-    ] = None
-    includedDataCatalog: Optional[Union["DataCatalog", List["DataCatalog"]]] = None
-    includedInDataCatalog: Optional[Union["DataCatalog", List["DataCatalog"]]] = None
-    datasetTimeInterval: Optional[Union[datetime, List[datetime]]] = None
-    distribution: Optional[Union["DataDownload", List["DataDownload"]]] = None
+    catalog: Union["DataCatalog", List["DataCatalog"]] = None
+    variablesMeasured: Union[str, List[str], "PropertyValue", List["PropertyValue"]] = None
+    variableMeasured: Union[str, List[str], "PropertyValue", List["PropertyValue"]] = None
+    includedDataCatalog: Union["DataCatalog", List["DataCatalog"]] = None
+    includedInDataCatalog: Union["DataCatalog", List["DataCatalog"]] = None
+    datasetTimeInterval: Union[datetime, List[datetime]] = None
+    distribution: Union["DataDownload", List["DataDownload"]] = None
 
 
 class DataCatalog(CreativeWork):
@@ -775,24 +762,20 @@ class DataCatalog(CreativeWork):
     A collection of datasets.
     """
 
-    measurementMethod: Optional[
-        Union[
-            HttpUrl,
-            List[HttpUrl],
-            DefinedTerm,
-            List[DefinedTerm],
-            str,
-            List[str],
-        ]
+    measurementMethod: Union[
+        HttpUrl,
+        List[HttpUrl],
+        DefinedTerm,
+        List[DefinedTerm],
+        str,
+        List[str],
     ] = None
-    dataset: Optional[Union[Dataset, List[Dataset]]] = None
-    measurementTechnique: Optional[
-        Union[
-            str,
-            List[str],
-            HttpUrl,
-            List[HttpUrl],
-            DefinedTerm,
-            List[DefinedTerm],
-        ]
+    dataset: Union[Dataset, List[Dataset]] = None
+    measurementTechnique: Union[
+        str,
+        List[str],
+        HttpUrl,
+        List[HttpUrl],
+        DefinedTerm,
+        List[DefinedTerm],
     ] = None

--- a/schema/src/core.py
+++ b/schema/src/core.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import List, Union
 
 
 from pydantic import (
@@ -53,10 +53,11 @@ class CoreMetadata(SchemaBaseModel):
         #            "enum": ["Dataset", "Notebook", "Software Source Code"],
         #        },
     )
-    additionalType: Optional[str] = Field(
+    additionalType: str = Field(
         title="Additional type",
         description="An additional type for the resource. This can be used to further specify the type of the"
                     " resource (e.g., Composite Resource).",
+        default=None,
     )
     name: str = Field(
         title="Name or title",
@@ -100,60 +101,60 @@ class CoreMetadata(SchemaBaseModel):
     ###################
     # OPTIONAL FIELDS #
     ###################
-    contributor: Optional[List[Union[Contributor, Organization]]] = Field(
+    contributor: List[Union[Contributor, Organization]] = Field(
         description="Person or Organization that contributed to the resource.",
         default=None
     )
-    publisher: Optional[PublisherOrganization] = Field(
+    publisher: PublisherOrganization = Field(
         title="Publisher",
         description="Where the resource is permanently published, indicated the repository, service provider,"
         " or organization that published the resource - e.g., CUAHSI HydroShare."
         " This may be the same as Provider.",
         default=None,
     )
-    datePublished: Optional[datetime] = Field(
+    datePublished: datetime = Field(
         title="Date published",
         description="Date of first publication for the resource.",
         default=None,
     )
-    subjectOf: Optional[List[SubjectOf]] = Field(
+    subjectOf: List[SubjectOf] = Field(
         title="Subject of",
         description="Link to or citation for a related resource that is about or describes this resource"
         " - e.g., a journal paper that describes this resource or a related metadata document "
         "describing the resource.",
         default=None,
     )
-    version: Optional[str] = Field(
+    version: str = Field(
         description="A text string indicating the version of the resource.",
         default=None,
     )  # TODO find something better than float for number
-    inLanguage: Optional[Union[LanguageEnum, InLanguageStr]] = Field(
+    inLanguage: Union[LanguageEnum, InLanguageStr] = Field(
         title="Language",
         description="The language of the content of the resource.",
         default=None,
     )
-    creativeWorkStatus: Optional[Union[Draft, Incomplete, Obsolete, Published]] = Field(
+    creativeWorkStatus: Union[Draft, Incomplete, Obsolete, Published] = Field(
         title="Resource status",
         description="The status of this resource in terms of its stage in a lifecycle. "
         "Example terms include Incomplete, Draft, Published, and Obsolete.",
         default=None,
     )
-    dateModified: Optional[datetime] = Field(
+    dateModified: datetime = Field(
         title="Date modified",
         description="The date on which the resource was most recently modified or updated.",
         default=None,
     )
-    funding: Optional[List[Grant]] = Field(
+    funding: List[Grant] = Field(
         description="A Grant or monetary assistance that directly or indirectly provided funding or sponsorship "
         "for creation of the resource.",
         default=None,
     )
-    temporalCoverage: Optional[TemporalCoverage] = Field(
+    temporalCoverage: TemporalCoverage = Field(
         title="Temporal coverage",
         description="The time period that applies to all of the content within the resource.",
         default=None,
     )
-    spatialCoverage: Optional[Place] = Field(
+    spatialCoverage: Place = Field(
         description="The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. "
         "It is a sub property of contentLocation intended primarily for more technical and "
         "detailed materials. For example with a Dataset, it indicates areas that the dataset "
@@ -161,30 +162,30 @@ class CoreMetadata(SchemaBaseModel):
         "place: the state of New York.",
         default=None,
     )
-    hasPart: Optional[List[HasPart]] = Field(
+    hasPart: List[HasPart] = Field(
         title="Has part",
         description="Link to or citation for a related resource that is part of this resource.",
         default=None,
     )
-    isPartOf: Optional[List[IsPartOf]] = Field(
+    isPartOf: List[IsPartOf] = Field(
         title="Is part of",
         description="Link to or citation for a related resource that this resource is a "
         "part of - e.g., a related collection.",
         default=None,
     )
-    additionalProperty: Optional[List[PropertyValue]] = Field(
+    additionalProperty: List[PropertyValue] = Field(
         title="Additional properties",
         default=None,
         description="Additional properties of the place.",
     )
 
     # using MediaType here to allow for MediaObject and its subclasses (e.g., DataDownload, VideoObject)
-    associatedMedia: Optional[Union[MediaType, List[MediaType]]] = Field(
+    associatedMedia: Union[MediaType, List[MediaType]] = Field(
         title="Resource content",
         description="A media object that encodes this CreativeWork. This property is a synonym for encoding.",
         default=None,
     )
-    citation: Optional[List[str]] = Field(
+    citation: List[str] = Field(
         title="Citation",
         description="A bibliographic citation for the resource.",
         default=None,

--- a/schema/src/dataset.py
+++ b/schema/src/dataset.py
@@ -1,10 +1,11 @@
 from .core import CoreMetadata
 from enum import Enum
-from typing import Optional, List, Union, Literal
+from typing import List, Union, Literal
 from pydantic import Field, HttpUrl
 from datetime import datetime
 
 from .base import (
+    Grant,
     Public,
     Published,
     Discoverable,
@@ -16,6 +17,9 @@ from .base import (
     CreativeWork,
     Provider,
     MediaType,
+    SchemaBaseModel,
+    TemporalCoverage,
+    Place,
 )
 
 from .datavariable import Dimension, DataVariable
@@ -62,31 +66,29 @@ class ScientificDataset(CoreMetadata):
         description="A media object that encodes this CreativeWork. This property is a synonym for encoding.",
     )
     
-    coordinates: Optional[List[DataVariable]] = Field(
+    coordinates: List[DataVariable] = Field(
         default=None,
         title="Coordinates",
         description="Coordinate variables that provide values along a dimension",
     )
 
-    includedInDataCatalog: Optional[DataCatalog] = Field(
+    includedInDataCatalog: DataCatalog = Field(
         default=None,
         title="DataCatalog",
         description="A data catalog which contains this dataset.",
     )
 
-    additionalProperty: Optional[
-        Union[str, List[str], PropertyValue, List[PropertyValue]]
-    ] = Field(
+    additionalProperty: Union[str, List[str], PropertyValue, List[PropertyValue]] = Field(
         title="Additional properties",
         default=None,
         description="Additional properties of the dataset that don't fit into schema org.",
     )
-    sourceOrganization: Optional[Organization] = Field(
+    sourceOrganization: Organization = Field(
         default=None,
         title="Source organization",
         description="The organization that provided the data for this dataset.",
     )
-    additionalType: Optional[AdditionalType] = Field(
+    additionalType: AdditionalType = Field(
         default=None,
         title="Additional Type",
         description = "Additional descriptive types associated with the ScientificDataset. This is typically used by applications to provide specialized funcationality for categories for content."
@@ -97,24 +99,24 @@ class ScientificDataset(CoreMetadata):
     # but preserve the metadata defined in the
     # parent class
     # ---------------------------------------------
-    name: Optional[str] = Field(
+    name: str = Field(
         default=None,
         title="Name or title",
         description="A text string with a descriptive name or title for the resource.",
     )
-    description: Optional[str] = Field(
+    description: str = Field(
         default=None,
         title="Description or abstract",
         description="A text string containing a description/abstract for the resource.",
     )
-    url: Optional[HttpUrl] = Field(
+    url: HttpUrl = Field(
         default=None,
         title="URL",
         description="A URL for the landing page that describes the resource and where the content "
         "of the resource can be accessed. If there is no landing page,"
         " provide the URL of the content.",
     )
-    identifier: Optional[List[str]] = Field(
+    identifier: List[str] = Field(
         default=None,
         title="Identifiers",
         description="Any kind of identifier for the resource. Identifiers may be DOIs or unique strings "
@@ -122,27 +124,85 @@ class ScientificDataset(CoreMetadata):
         "encoded as URLs, enter URLs here.",
     )
 
-    creator: Optional[List[Union[Creator, Organization]]] = Field(
+    creator: List[Union[Creator, Organization]] = Field(
         default=None, description="Person or Organization that created the resource."
     )
-    dateCreated: Optional[datetime] = Field(
+    dateCreated: datetime = Field(
         default=None,
         title="Date created",
         description="The date on which the resource was created.",
     )
-    keywords: Optional[List[str]] = Field(
+    keywords: List[str] = Field(
         default=None,
         description="Keywords or tags used to describe the dataset, delimited by commas.",
     )
-    license: Optional[Union[CreativeWork, HttpUrl]] = Field(
+    license: Union[CreativeWork, HttpUrl] = Field(
         default=None, description="A license document that applies to the resource."
     )
-    provider: Optional[Union[Organization, Provider]] = Field(
+    provider: Union[Organization, Provider] = Field(
         default=None,
         description="The repository, service provider, organization, person, or service performer that provides"
         " access to the resource.",
     )
-    sharing_status: Optional[Union[Public, Published, Private, Discoverable]] = Field(
+    sharing_status: Union[Public, Published, Private, Discoverable] = Field(
         default=None,
         description="The Sharing status of the resource. This is a controlled vocabulary term from CUAHSI HydroShare",
     )
+
+class EditableScientificDataset(SchemaBaseModel):
+    name: str = Field(
+        default=None,
+        title="Name or title",
+        description="A text string with a descriptive name or title for the resource.",
+    )
+    description: str = Field(
+        default=None,
+        title="Description or abstract",
+        description="A text string containing a description/abstract for the resource.",
+    )
+    keywords: List[str] = Field(
+        default=None,
+        description="Keywords or tags used to describe the dataset, delimited by commas.",
+    )
+    license: Union[CreativeWork, HttpUrl] = Field(
+        default=None, description="A license document that applies to the resource."
+    )
+    provider: Union[Organization, Provider] = Field(
+        default=None,
+        description="The repository, service provider, organization, person, or service performer that provides"
+        " access to the resource.",
+    )
+    additionalProperty: Union[str, List[str], PropertyValue, List[PropertyValue]] = Field(
+        title="Additional properties",
+        default=None,
+        description="Additional properties of the dataset that don't fit into schema org.",
+    )
+    funding: List[Grant] = Field(
+        description="A Grant or monetary assistance that directly or indirectly provided funding or sponsorship "
+        "for creation of the resource.",
+        default=None,
+    )
+    temporalCoverage: TemporalCoverage = Field(
+        title="Temporal coverage",
+        description="The time period that applies to all of the content within the resource.",
+        default=None,
+    )
+    spatialCoverage: Place = Field(
+        description="The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. "
+        "It is a sub property of contentLocation intended primarily for more technical and "
+        "detailed materials. For example with a Dataset, it indicates areas that the dataset "
+        "describes: a dataset of New York weather would have spatialCoverage which was the "
+        "place: the state of New York.",
+        default=None,
+    )
+    citation: List[str] = Field(
+        title="Citation",
+        description="A bibliographic citation for the resource.",
+        default=None,
+    )
+    model_config = {
+        "arbitrary_types_allowed": True,
+        "json_encoders": {
+            HttpUrl: str,  # Convert HttpUrl to a string during serialization
+        },
+    }

--- a/schema/src/datavariable.py
+++ b/schema/src/datavariable.py
@@ -5,7 +5,7 @@ CUAHSI's extension to the SchemaOrg vocabulary to better encapsulate
 scientific data variable metadata.
 """
 
-from typing import Optional, Literal, Union
+from typing import Literal, Union
 from pydantic import Field, BaseModel, HttpUrl
 
 
@@ -35,7 +35,7 @@ class Dimension(BaseModel):
         title="Variable Shape",
         description="The shape of the variable",
     )
-    description: Optional[str] = Field(
+    description: str = Field(
         default=None,
         title="Variable Description",
         description="The description of the variable measured",
@@ -64,32 +64,32 @@ class DataVariable(BaseModel):
         title="Variable Dimensions",
         description="The dimension names corresponding to the variable being measured",
     )
-    description: Optional[str] = Field(
+    description: str = Field(
         default=None,
         title="Variable Description",
         description="The description of the variable measured",
     )
-    dataType: Optional[str] = Field(
+    dataType: str = Field(
         default=None,
         title="The data type of the variable",
         description="The data type of the variable measured",
     )
-    unit: Optional[str] = Field(
+    unit: str = Field(
         default=None,
         title="Variable Unit",
         description="The unit of the variable measured",
     )
-    minValue: Optional[Union[float,str]] = Field(
+    minValue: Union[float,str] = Field(
         title="Minimum Value",
         description="The minimum value in the raster grid",
         default=None,
     )
-    maxValue: Optional[Union[float,str]] = Field(
+    maxValue: Union[float,str] = Field(
         title="Maximum Value",
         description="The maximum value in the raster grid",
         default=None,
     )
-    noDataValue: Optional[Union[float,str]] = Field(
+    noDataValue: Union[float,str] = Field(
         title="No Data Value",
         description="The numerical value used to represent null data in the raster grid",
         default=None,


### PR DESCRIPTION
The Optional annotation causes issues with the json forms rendering of the json schema. It isn't necessary to use the Optional annotation as having a default=None marks the property as optional.